### PR TITLE
Use HTTPS for NSW Rural Fire feed

### DIFF
--- a/geojson_client/nsw_rural_fire_service_feed.py
+++ b/geojson_client/nsw_rural_fire_service_feed.py
@@ -33,7 +33,7 @@ REGEXP_ATTR_SIZE = 'SIZE: (?P<{}>[^<]+) <br'.format(CUSTOM_ATTRIBUTE)
 REGEXP_ATTR_STATUS = 'STATUS: (?P<{}>[^<]+) <br'.format(CUSTOM_ATTRIBUTE)
 REGEXP_ATTR_TYPE = 'TYPE: (?P<{}>[^<]+) <br'.format(CUSTOM_ATTRIBUTE)
 
-URL = "http://www.rfs.nsw.gov.au/feeds/majorIncidents.json"
+URL = "https://www.rfs.nsw.gov.au/feeds/majorIncidents.json"
 
 VALID_CATEGORIES = ['Emergency Warning', 'Watch and Act', 'Advice',
                     'Not Applicable']

--- a/tests/test_nsw_rural_fire_service_feed.py
+++ b/tests/test_nsw_rural_fire_service_feed.py
@@ -26,7 +26,7 @@ class TestNswRuralFireServiceFeed(unittest.TestCase):
         feed = NswRuralFireServiceFeed(home_coordinates, None)
         assert repr(feed) == "<NswRuralFireServiceFeed(" \
                              "home=(-31.0, 151.0), " \
-                             "url=http://www.rfs.nsw.gov.au/feeds/" \
+                             "url=https://www.rfs.nsw.gov.au/feeds/" \
                              "majorIncidents.json, radius=None, " \
                              "categories=None)>"
         status, entries = feed.update()
@@ -119,7 +119,7 @@ class TestNswRuralFireServiceFeed(unittest.TestCase):
         assert repr(feed_manager) == "<NswRuralFireServiceFeedManager(" \
                                      "feed=<NswRuralFireServiceFeed(" \
                                      "home=(-31.0, 151.0), " \
-                                     "url=http://www.rfs.nsw.gov.au/feeds/" \
+                                     "url=https://www.rfs.nsw.gov.au/feeds/" \
                                      "majorIncidents.json, radius=None, " \
                                      "categories=None)>)>"
         feed_manager.update()


### PR DESCRIPTION
This small fix uses HTTPS to secure load the feed, over insecure http as it was before.  The same feed is delivered, just over this secure protocol for improvements in security, data integrity and privacy.